### PR TITLE
Format int64 comparison as OData long

### DIFF
--- a/src/Tables.FSharp/FilterConverter.fs
+++ b/src/Tables.FSharp/FilterConverter.fs
@@ -55,7 +55,7 @@ module private StringValue =
 
     let forLong (value:int64) =
         Convert.ToString(value, formatProvider)
-        |> sprintf "'%s'"
+        |> sprintf "%sL"
 
     let forAny (v:obj) = Convert.ToString(v, formatProvider) |> sprintf "'%s'"
 


### PR DESCRIPTION
Filters using int64 weren't working because they were filtering as on a stringified int value instead. This seems to fix them.