### PR TITLE
Run tests that query int64 values

### DIFF
--- a/tests/Tables.FSharp.Tests/Data.fs
+++ b/tests/Tables.FSharp.Tests/Data.fs
@@ -32,13 +32,13 @@ let getEntity id (i:int) =
     e.DateVal <- DateTimeOffset(now.Year, now.Month, now.Day, i, 0, 0, TimeSpan.Zero)
     e.DoubleVal <- float i * 1.5
     e.IntVal <- i
-    e.Int64Val <- int64 i
+    e.Int64Val <- int64 i * 1_000_000_000_000L
     e
 
 let prepareData (client:TableClient) =
     client.CreateIfNotExists() |> ignore
-    client.Delete() |> ignore
-    client.CreateIfNotExists() |> ignore
+    for e in client.Query<TableEntity>() do
+        client.DeleteEntity(e.PartitionKey, e.RowKey) |> ignore<Response>
     [1..9]
     |> List.map (getEntity <| Guid.NewGuid())
     |> List.iter (client.UpsertEntity >> ignore)

--- a/tests/Tables.FSharp.Tests/QueryTests.fs
+++ b/tests/Tables.FSharp.Tests/QueryTests.fs
@@ -72,7 +72,7 @@ let queryFilterTests (client:TableClient) = testList "Filter" [
 
     test "Filters by Int64" {
         let ent =
-            eq "Int64Val" 5L
+            eq "Int64Val" 5_000_000_000_000L
             |> client.Query<Data.TestEntity>
             |> Seq.toList
 
@@ -82,7 +82,7 @@ let queryFilterTests (client:TableClient) = testList "Filter" [
 
     test "Unary filter works" {
         let ent =
-            !! (eq "Int64Val" 5L)
+            !! (eq "Int64Val" 5_000_000_000_000L)
             |> client.Query<Data.TestEntity>
             |> Seq.toList
 


### PR DESCRIPTION
These tests use int64 values in the queries (not representable as 32-bit integers) to ensure the generated queries work properly against int64 columns.